### PR TITLE
Prompt to download and install ffmpeg

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,11 +101,14 @@
     "test": "npm run compile && node ./node_modules/vscode/bin/test"
   },
   "devDependencies": {
+    "@types/fs-extra": "^5.0.4",
+    "@types/node": "^10.12.19",
     "typescript": "^3.2.2",
-    "vscode": "^1.1.26",
-    "@types/node": "^10.12.19"
+    "vscode": "^1.1.26"
   },
   "dependencies": {
-    "@arcsine/screen-recorder": "^0.1.1"
+    "@arcsine/screen-recorder": "^0.1.1",
+    "ffbinaries": "^1.1.1",
+    "fs-extra": "^7.0.1"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   Util.context = context;
 
-  const recorder = new Recorder();
+  const recorder = new Recorder(context);
   const status = new RecordingStatus();
 
   async function stop() {
@@ -27,7 +27,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   async function record(opts: Partial<RecordingOptions> = {}) {
     try {
-      if (!(await Config.getFFmpegBinary())) {
+      if (!(await Config.getFFmpegBinary(context))) {
         vscode.window.showWarningMessage('FFmpeg binary location not defined, cannot record unless path is set.');
         return;
       }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,0 +1,125 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { Log, decorators } from './log';
+const ffbinaries = require('ffbinaries');
+
+const installDirectoryKey = 'installDir1';
+
+export type FFMpegInstallPickerOptions = {
+    title: string;
+    folder?: boolean;
+    defaultName?: string;
+    executable?: boolean;
+    platformDefaults?: { darwin?: string[]; win32?: string[]; x11?: string[] };
+    validator?: (res: string) => Promise<boolean> | boolean;
+    onAdd?: (file: string) => Promise<any> | any;
+};
+
+export class Installer {
+    constructor(private readonly context: vscode.ExtensionContext, private readonly helper: InstallerHelper) {}
+    public async getInstallDirectory(options: FFMpegInstallPickerOptions): Promise<string | undefined> {
+        const shouldInstall = await this.helper.shouldInstall();
+        if (!shouldInstall) {
+            return this.helper.pickExistingInstallation(options);
+        }
+        try {
+            const existingDir = await this.getExistingInstallDirectory();
+            if (existingDir) {
+                return;
+            }
+            const dir = await this.helper.pickTargetInstallDirectory();
+            if (!dir) {
+                return;
+            }
+            await this.helper.ensureInstallDirectory(dir);
+            const ffmpegFile = await this.helper.install(dir);
+            await this.trackInstallation(ffmpegFile);
+            return ffmpegFile;
+        } catch (ex) {
+            Log.error(`Failed to download ffmpeg, '${ex}'`);
+            const showLogs = 'View Logs';
+            const selection = await vscode.window.showErrorMessage('Failed to download ffmpeg', showLogs);
+            if (selection === showLogs) {
+                Log.showLog();
+            }
+        }
+    }
+    private async trackInstallation(dir: string): Promise<void> {
+        await this.context.globalState.update(installDirectoryKey, dir);
+    }
+    private async getExistingInstallDirectory(): Promise<string | undefined> {
+        const dir = this.context.globalState.get<string>(installDirectoryKey, '');
+        if (dir.length === 0) {
+            return;
+        }
+        return (await fs.pathExists(dir)) ? dir : '';
+    }
+}
+export class InstallerHelper {
+    constructor(private readonly context: vscode.ExtensionContext) {}
+    public async shouldInstall(): Promise<boolean> {
+        const msg = 'Please provide the install directory of ffmpeg or would you like to download and install it?';
+        const existingInstall = 'Pick existing install';
+        const downloadAndInstall = 'Download and install';
+        const option = await vscode.window.showInformationMessage(msg, existingInstall, downloadAndInstall);
+        return option === downloadAndInstall;
+    }
+    public async pickExistingInstallation(options: FFMpegInstallPickerOptions): Promise<string | undefined> {
+        const res = await vscode.window.showOpenDialog({
+            openLabel: `Select ${options.title}`,
+            canSelectFiles: !options.folder,
+            canSelectFolders: options.folder,
+            canSelectMany: false
+        });
+
+        if (!res || res.length === 0) {
+            return;
+        }
+
+        return res[0].fsPath;
+    }
+    public async pickTargetInstallDirectory(): Promise<string | undefined> {
+        const res = await vscode.window.showOpenDialog({
+            openLabel: 'Select target directory',
+            canSelectFiles: false,
+            canSelectFolders: true,
+            canSelectMany: false
+        });
+
+        const dir = res && res.length === 1 ? res[0].fsPath : undefined;
+        if (!dir) {
+            return;
+        }
+        const files = await fs.readdir(dir);
+        if (Array.isArray(files) && files.length > 0) {
+            vscode.window.showErrorMessage('Please select an empty directory to install ffmpeg');
+            return;
+        }
+        return dir;
+    }
+    @decorators.error('Failed to install ffmpeg')
+    public async install(destination: string): Promise<string> {
+        Log.info(`Installing ffmpeg into ${destination}`);
+        await new Promise((resolve, reject) =>
+            ffbinaries.downloadBinaries('ffmpeg', { destination }, (ex: any) => (ex ? reject(ex) : resolve()))
+        );
+        const fileName = path.join(destination, ffbinaries.getBinaryFilename('ffmpeg'));
+        if (!(await fs.pathExists(fileName))) {
+            const msg = `Downloaded ffmpeg file not found '${fileName}'`;
+            throw new Error(msg);
+        }
+        return fileName;
+    }
+    @decorators.error('Failed to uninstall ffmpeg')
+    public async uninstall(destination: string): Promise<void> {
+        Log.info(`Uninstalling ffmpeg from ${destination}`);
+        await fs.remove(destination);
+    }
+    @decorators.error('Failed to create ffmpeg install directory')
+    public async ensureInstallDirectory(dir: string): Promise<void> {
+        if (!(await fs.pathExists(dir))) {
+            await fs.ensureDir(dir);
+        }
+    }
+}

--- a/src/log.ts
+++ b/src/log.ts
@@ -2,19 +2,86 @@ import * as vscode from 'vscode';
 import { Config } from './config';
 
 export class Log {
-  static output = vscode.window.createOutputChannel('chronicler');
-
-  static info(msg: string) {
-    this.output.appendLine(`[INFO] ${msg}`);
-  }
-
-  static error(error: string) {
-    this.output.appendLine(`[ERROR] ${error}`);
-  }
-
-  static debug(msg: string) {
-    if (Config.isDebugMode()) {
-      this.output.appendLine(`[ERROR] ${msg}`);
+    static output = vscode.window.createOutputChannel('chronicler');
+	static showLog() {
+		Log.output.show(true);
+	}
+    static info(msg: string) {
+        this.output.appendLine(`[INFO] ${msg}`);
     }
-  }
+
+    static error(error: string) {
+        this.output.appendLine(`[ERROR] ${error}`);
+    }
+
+    static debug(msg: string) {
+        if (Config.isDebugMode()) {
+            this.output.appendLine(`[ERROR] ${msg}`);
+        }
+    }
+}
+
+enum LogLevel {
+    info = 'info',
+    error = 'error',
+    debug = 'debug'
+}
+
+export namespace decorators {
+    export function debug(message: string) {
+        return trace(message, LogLevel.debug);
+    }
+    export function error(message: string) {
+        return trace(message, LogLevel.error);
+    }
+    export function info(message: string) {
+        return trace(message, LogLevel.info);
+    }
+}
+
+const loggerMethods = {
+    info: Log.info,
+    error: Log.error,
+    debug: Log.debug
+};
+
+function trace(message: string, logLevel: LogLevel) {
+    return function(_: Object, __: string, descriptor: TypedPropertyDescriptor<any>) {
+        const originalMethod = descriptor.value;
+        descriptor.value = function(...args: any[]) {
+            function writeSuccess() {
+                // If log level is errors, then no need to log any success messages.
+                if (logLevel === LogLevel.error) {
+                    return;
+                }
+                writeToLog();
+            }
+            function writeError(ex: Error) {
+                writeToLog(ex);
+            }
+            // tslint:disable-next-line:no-any
+            function writeToLog(ex?: Error) {
+                const messagesToLog = [message];
+                if (ex) {
+                    messagesToLog.push(`${ex}`);
+                }
+                loggerMethods[logLevel](messagesToLog.join(', '));
+            }
+            try {
+                const result = originalMethod.apply(this, args);
+                // If method being wrapped returns a promise then wait for it.
+                if (result && typeof result.then === 'function' && typeof result.catch === 'function') {
+                    (result as Promise<void>).then(writeSuccess).catch(writeError);
+                } else {
+                    writeSuccess();
+                }
+                return result;
+            } catch (ex) {
+                writeError(ex);
+                throw ex;
+            }
+        };
+
+        return descriptor;
+    };
 }

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -3,8 +3,10 @@ import { Recorder as ScreenRecorder, RecordingOptions as Recop, GIFCreator } fro
 import { Config } from './config';
 import { RecordingOptions } from './types';
 import { ChildProcess } from 'child_process';
+import { ExtensionContext } from 'vscode';
 
 export class Recorder {
+	constructor(private readonly context:ExtensionContext){}
 
   private proc: {
     proc: ChildProcess,
@@ -45,13 +47,14 @@ export class Recorder {
   }
 
   async run(override: Partial<RecordingOptions> = {}) {
-    const binary = (await Config.getFFmpegBinary())!;
+    const binary = (await Config.getFFmpegBinary(this.context))!;
 
-    const opts = {
-      ...Config.getRecordingDefaults(),
-      file: await Config.getFilename(),
-      ...override,
-      ffmpegBinary: binary
+		const opts = {
+			...Config.getRecordingDefaults(),
+			file: await Config.getFilename(),
+			...override,
+			ffmpegBinary: binary,
+      ffmpeg: { binary: binary }
     };
 
     if (this.proc) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+		"experimentalDecorators": true,
         "module": "commonjs",
         "outDir": "out",
         "target": "es2018",


### PR DESCRIPTION
Provides a smooth install and UX, with option to download and install ffmpeg.
Also fixed a problem with the args passed to ffmpeg. 

Workflow:
* Existing functionality left intact
* Prompt to install or select install directory
* If you select new install directory, 
	* Download
	* Save this for future usage (into settings as done today)