### PR TITLE
Adding Live Share integration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,5 @@
   },
   "cSpell.words": [
     "Resizer"
-  ],
-  "workbench.colorCustomizations": {}
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
   },
   "cSpell.words": [
     "Resizer"
-  ]
+  ],
+  "workbench.colorCustomizations": {}
 }

--- a/package.json
+++ b/package.json
@@ -32,68 +32,73 @@
   "main": "./out/extension",
   "contributes": {
     "commands": [
-    {
-      "title": "Start Recording",
-      "category": "Chronicler",
-      "command": "chronicler.record"
-    },
-    {
-      "title": "Start Recording GIF",
-      "category": "Chronicler",
-      "command": "chronicler.recordGif"
-    },
-    {
-      "title": "Start Recording with Audio",
-      "category": "Chronicler",
-      "command": "chronicler.recordWithAudio"
-    },
-    {
-      "title": "Start Timed-Recording",
-      "category": "Chronicler",
-      "command": "chronicler.recordWithDuration"
-    },
-    {
-      "title": "Stop Recording",
-      "category": "Chronicler",
-      "command": "chronicler.stop"
-    }],
+      {
+        "title": "Start Recording",
+        "category": "Chronicler",
+        "command": "chronicler.record"
+      },
+      {
+        "title": "Start Recording GIF",
+        "category": "Chronicler",
+        "command": "chronicler.recordGif"
+      },
+      {
+        "title": "Start Recording with Audio",
+        "category": "Chronicler",
+        "command": "chronicler.recordWithAudio"
+      },
+      {
+        "title": "Start Timed-Recording",
+        "category": "Chronicler",
+        "command": "chronicler.recordWithDuration"
+      },
+      {
+        "title": "Stop Recording",
+        "category": "Chronicler",
+        "command": "chronicler.stop"
+      }],
     "keybindings": [
-    {
-      "key": "ctrl+alt+shift+r",
-      "mac": "cmd+alt+shift+r",
-      "command": "chronicler.record"
-    },
-    {
-      "key": "ctrl+alt+shift+s",
-      "mac": "cmd+alt+shift+s",
-      "command": "chronicler.stop"
-    }],
+      {
+        "key": "ctrl+alt+shift+r",
+        "mac": "cmd+alt+shift+r",
+        "command": "chronicler.record"
+      },
+      {
+        "key": "ctrl+alt+shift+s",
+        "mac": "cmd+alt+shift+s",
+        "command": "chronicler.stop"
+      }],
     "configuration": [
-    {
-      "title": "Chronicler",
-      "properties": {
-        "chronicler.ffmpeg-binary": {
-          "description": "FFmpeg Binary Location",
-          "type": "string"
-        },
-        "chronicler.dest-folder": {
-          "description": "Output Folder for Captures",
-          "type": "~/Recordings"
-        },
-        "chronicler.recording-defaults": {
-          "description": "Recording defaults",
-          "type": "object",
-          "default": {
-            "fps": 10,
-            "countdown": 5
+      {
+        "title": "Chronicler",
+        "properties": {
+          "chronicler.ffmpeg-binary": {
+            "description": "FFmpeg Binary Location",
+            "type": "string"
+          },
+          "chronicler.dest-folder": {
+            "description": "Output Folder for Captures",
+            "type": "~/Recordings"
+          },
+          "chronicler.recording-defaults": {
+            "description": "Recording defaults",
+            "type": "object",
+            "default": {
+              "fps": 10,
+              "countdown": 5
+            }
+          },
+          "chronicler.debug": {
+            "description": "Run with debug logging enabled",
+            "type": "boolean"
+          },
+          "chronicler.auto-record-live-share": {
+            "description": "Specifies whether recording should automatically start and stop when in a Live Share session",
+            "type": "boolean",
+            "default": false
           }
-        },
-        "chronicler.debug": {
-          "description": "Run with debug logging enabled",
-          "type": "boolean"
         }
-      }
-    }]
+      }]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
@@ -108,6 +113,7 @@
     "@types/node": "^10.12.19"
   },
   "dependencies": {
-    "@arcsine/screen-recorder": "^0.1.5"
+    "@arcsine/screen-recorder": "^0.1.5",
+    "vsls": "^0.3.1291"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chronicler",
   "displayName": "Chronicler",
   "description": "Visual Studio Session Recorder",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "publisher": "arcsine",
   "repository": {
     "type": "git",
@@ -32,31 +32,31 @@
   "main": "./out/extension",
   "contributes": {
     "commands": [
-      {
-        "title": "Start Recording",
-        "category": "Chronicler",
-        "command": "chronicler.record"
-      },
-      {
-        "title": "Start Recording GIF",
-        "category": "Chronicler",
-        "command": "chronicler.recordGif"
-      },
-      {
-        "title": "Start Recording with Audio",
-        "category": "Chronicler",
-        "command": "chronicler.recordWithAudio"
-      },
-      {
-        "title": "Start Timed-Recording",
-        "category": "Chronicler",
-        "command": "chronicler.recordWithDuration"
-      },
-      {
-        "title": "Stop Recording",
-        "category": "Chronicler",
-        "command": "chronicler.stop"
-      }],
+    {
+      "title": "Start Recording",
+      "category": "Chronicler",
+      "command": "chronicler.record"
+    },
+    {
+      "title": "Start Recording GIF",
+      "category": "Chronicler",
+      "command": "chronicler.recordGif"
+    },
+    {
+      "title": "Start Recording with Audio",
+      "category": "Chronicler",
+      "command": "chronicler.recordWithAudio"
+    },
+    {
+      "title": "Start Timed-Recording",
+      "category": "Chronicler",
+      "command": "chronicler.recordWithDuration"
+    },
+    {
+      "title": "Stop Recording",
+      "category": "Chronicler",
+      "command": "chronicler.stop"
+    }],
     "keybindings": [
     {
       "key": "ctrl+alt+shift+r",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chronicler",
   "displayName": "Chronicler",
   "description": "Visual Studio Session Recorder",
-  "version": "0.0.9",
+  "version": "0.1.1",
   "publisher": "arcsine",
   "repository": {
     "type": "git",
@@ -58,47 +58,47 @@
         "command": "chronicler.stop"
       }],
     "keybindings": [
-      {
-        "key": "ctrl+alt+shift+r",
-        "mac": "cmd+alt+shift+r",
-        "command": "chronicler.record"
-      },
-      {
-        "key": "ctrl+alt+shift+s",
-        "mac": "cmd+alt+shift+s",
-        "command": "chronicler.stop"
-      }],
+    {
+      "key": "ctrl+alt+shift+r",
+      "mac": "cmd+alt+shift+r",
+      "command": "chronicler.record"
+    },
+    {
+      "key": "ctrl+alt+shift+s",
+      "mac": "cmd+alt+shift+s",
+      "command": "chronicler.stop"
+    }],
     "configuration": [
-      {
-        "title": "Chronicler",
-        "properties": {
-          "chronicler.ffmpeg-binary": {
-            "description": "FFmpeg Binary Location",
-            "type": "string"
-          },
-          "chronicler.dest-folder": {
-            "description": "Output Folder for Captures",
-            "type": "~/Recordings"
-          },
-          "chronicler.recording-defaults": {
-            "description": "Recording defaults",
-            "type": "object",
-            "default": {
-              "fps": 10,
-              "countdown": 5
-            }
-          },
-          "chronicler.debug": {
-            "description": "Run with debug logging enabled",
-            "type": "boolean"
-          },
-          "chronicler.auto-record-live-share": {
-            "description": "Specifies whether recording should automatically start and stop when in a Live Share session",
-            "type": "boolean",
-            "default": false
+    {
+      "title": "Chronicler",
+      "properties": {
+        "chronicler.ffmpeg-binary": {
+          "description": "FFmpeg Binary Location",
+          "type": "string"
+        },
+        "chronicler.dest-folder": {
+          "description": "Output Folder for Captures",
+          "type": "~/Recordings"
+        },
+        "chronicler.recording-defaults": {
+          "description": "Recording defaults",
+          "type": "object",
+          "default": {
+            "fps": 10,
+            "countdown": 5
           }
+        },
+        "chronicler.debug": {
+          "description": "Run with debug logging enabled",
+          "type": "boolean"
+        },
+        "chronicler.auto-record-live-share": {
+          "description": "Specifies whether recording should automatically start and stop when in a Live Share session",
+          "type": "boolean",
+          "default": false
         }
-      }]
+      }
+    }]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/config.ts
+++ b/src/config.ts
@@ -204,4 +204,8 @@ export class Config {
       });
     }
   }
+
+  static getAutoRecordLiveShare() {
+    return this.getConfig('auto-record-live-share');
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as vsls from 'vsls';
 import { OSUtil } from '@arcsine/screen-recorder/lib/os';
 
 import { Recorder } from './recorder';
@@ -8,12 +9,23 @@ import { Util } from './util';
 import { RecordingOptions } from './types';
 import { Config } from './config';
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
 
   Util.context = context;
 
   const recorder = new Recorder();
   const status = new RecordingStatus();
+
+  const vslsApi = await vsls.getApi();
+  if (vslsApi && Config.getAutoRecordLiveShare()) {
+    vslsApi.onDidChangeSession((e) => {
+      if (e.session.role === vsls.Role.None) {
+        stop();
+      } else {
+        record();
+      }
+    });
+  }
 
   async function stop() {
     await new Promise(resolve => setTimeout(resolve, 125)); // Allows for click to be handled properly

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { OSUtil } from '@arcsine/screen-recorder/lib/os';
+import { LiveShare } from 'vsls';
 
 import { Recorder } from './recorder';
 import { RecordingStatus } from './status';
@@ -80,7 +81,7 @@ export async function activate(context: vscode.ExtensionContext) {
   async function initializeLiveShare() {
     if (Config.getAutoRecordLiveShare()) {
       const vsls = require('vsls');
-      const liveShare = vsls.getApi();
+      const liveShare: LiveShare = await vsls.getApi();
   
       if (liveShare) {
         liveShare.onDidChangeSession((e) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 import { OSUtil } from '@arcsine/screen-recorder/lib/os';
-import { LiveShare } from 'vsls';
 
 import { Recorder } from './recorder';
 import { RecordingStatus } from './status';
@@ -80,8 +79,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
   async function initializeLiveShare() {
     if (Config.getAutoRecordLiveShare()) {
-      const vsls = require('vsls');
-      const liveShare: LiveShare = await vsls.getApi();
+      const vsls = await import('vsls');
+      const liveShare = await vsls.getApi();
   
       if (liveShare) {
         liveShare.onDidChangeSession((e) => {


### PR DESCRIPTION
This PR adds [Live Share](https://aka.ms/vsls) integration, by allowing the end-user to automatically start and stop a recording when they're in a Live Share session. This way, if they want to record collaboration sessions, they can do it without needing to explicitly start/stop recording.

![Chronicler](https://user-images.githubusercontent.com/116461/59560095-b7b38880-8fc0-11e9-8454-5057d971e219.gif)
