### PR TITLE
fix: make dest-folder editable

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chronicler",
   "displayName": "Chronicler",
   "description": "Visual Studio Session Recorder",
-  "version": "0.1.2", 
+  "version": "0.1.2",
   "publisher": "arcsine",
   "repository": {
     "type": "git",
@@ -80,7 +80,8 @@
           },
           "chronicler.dest-folder": {
             "description": "Output Folder for Captures",
-            "type": "~/Recordings"
+            "type": "string",
+            "default": "~/Recordings"
           },
           "chronicler.recording-defaults": {
             "description": "Recording defaults",


### PR DESCRIPTION
Currently it is not possible to change `dest-folder` as its config type is wrong. This will fix it.